### PR TITLE
fix: readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Filament Log Manager
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/filipfonal/filament-log-manager.svg?style=flat-square)](https://packagist.org/packages/filipfonal/filament-log-manager)
-[![GitHub Tests Action Status](https://img.shields.io/github/workflow/status/filipfonal/filament-log-manager/run-tests?label=tests)](https://github.com/filipfonal/filament-log-manager/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/workflow/status/filipfonal/filament-log-manager/Fix%20PHP%20code%20style%20issues?label=code%20style)](https://github.com/filipfonal/filament-log-manager/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/filipfonal/filament-log-manager/run-tests.yml?branch=main&label=tests)](https://github.com/filipfonal/filament-log-manager/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/filipfonal/filament-log-manager/fix-php-code-style-issues.yml?branch=main&label=code%20style)](https://github.com/filipfonal/filament-log-manager/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/filipfonal/filament-log-manager.svg?style=flat-square)](https://packagist.org/packages/filipfonal/filament-log-manager)
 
 A simple and clear interface to preview, download and delete Laravel log files using Filament Admin.


### PR DESCRIPTION
Hello! I just wanted to update these ugly looking errors in your main readme file:

![obraz](https://user-images.githubusercontent.com/10898728/211166053-9af9a580-0792-44db-a0af-c68deca9edf1.png)

After changes it should look like this:

![obraz](https://user-images.githubusercontent.com/10898728/211166070-8afda7c4-13e7-4c94-9bbc-2a34fc45554d.png)

Further reading:
* https://github.com/badges/shields/issues/8671
