### PR TITLE
Added italian translation

### DIFF
--- a/resources/lang/it/translations.php
+++ b/resources/lang/it/translations.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'navigation_label' => 'Logs',
+    'navigation_group' => 'System',
+    'title' => 'Logs',
+    'search_placeholder' => 'Seleziona o cerca un file di log',
+    'no_logs' => 'Nessun file di log',
+    'delete' => 'Elimina',
+    'download' => 'Download',
+    'no_such_file' => 'Nessun file di log con questo nome',
+    'file_too_large' => 'File troppo grande per essere visualizzato',
+    'modal_delete_heading' => 'Elimina file di log?',
+    'modal_delete_subheading' => 'Sei sicuro di voler eliminare questo file di log?',
+    'modal_delete_action_cancel' => 'Annulla',
+    'modal_delete_action_confirm' => 'Elimina',
+];


### PR DESCRIPTION
This pull request adds Italian translations for log-related functionalities to the `resources/lang/it/translations.php` file.

Localization:

* [`resources/lang/it/translations.php`](diffhunk://#diff-9f718e21fd3e02026e296fc0d50f5adede695bcdf09d511ba36625adf472a23cR1-R17): Added Italian translations for navigation labels, titles, search placeholders, and modal actions related to log files.