### PR TITLE
Make searching optional but enabled by default

### DIFF
--- a/config/filament-log-manager.php
+++ b/config/filament-log-manager.php
@@ -33,4 +33,9 @@ return [
      * Allow set custom logs page class.
      */
     'page_class' => Logs::class,
+
+    /**
+     * Enable searching
+     */
+    'enable_search' => true,
 ];

--- a/src/Pages/Logs.php
+++ b/src/Pages/Logs.php
@@ -77,7 +77,7 @@ class Logs extends Page
     {
         return [
             Select::make('logFile')
-                ->searchable()
+                ->searchable(config('filament-log-manager.enable_search'))
                 ->reactive()
                 ->disableLabel()
                 ->placeholder(__('filament-log-manager::translations.search_placeholder'))


### PR DESCRIPTION
This does not change existing behavior, but allows users to disable search, or enable it when needed.

To reiterate, this PR ensures search is enabled by default, preserving default behavior.