### PR TITLE
Give user control over files lazy-loading behavior

### DIFF
--- a/config/filament-log-manager.php
+++ b/config/filament-log-manager.php
@@ -33,4 +33,9 @@ return [
      * Allow set custom logs page class.
      */
     'page_class' => Logs::class,
+
+    /**
+     * Allow lazy-loading files.
+     */
+    'allow_lazy_loading_files' => true,
 ];

--- a/src/Pages/Logs.php
+++ b/src/Pages/Logs.php
@@ -81,7 +81,11 @@ class Logs extends Page
                 ->reactive()
                 ->disableLabel()
                 ->placeholder(__('filament-log-manager::translations.search_placeholder'))
-                ->options(fn () => $this->getFileNames($this->getFinder())->take(5))
+                ->options(
+                    config('filament-log-manager.allow_lazy_loading_files')
+                        ? fn () => $this->getFileNames($this->getFinder())->take(5)
+                        : $this->getFileNames($this->getFinder())->take(5)
+                )
                 ->getSearchResultsUsing(fn (string $query) => $this->getFileNames($this->getFinder()->name("*{$query}*"))),
         ];
     }


### PR DESCRIPTION
Currently, user don't have control over whether files are lazy-loaded by default.

Currently, files are lazy-loaded, but for users that don't want that, this PR adds support for that.

Current default behavior is preserved, i.e. lazy-loading is enabled by default.