### PR TITLE
Add Portuguese translations for log management

### DIFF
--- a/resources/lang/pt_BR/translations.php
+++ b/resources/lang/pt_BR/translations.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'navigation_label' => 'Logs',
+    'navigation_group' => 'Sistema',
+    'title' => 'Logs',
+    'search_placeholder' => 'Selecione ou pesquise um arquivo de log',
+    'no_logs' => 'Nenhum log para exibir',
+    'delete' => 'Excluir',
+    'download' => 'Baixar',
+    'no_such_file' => 'Arquivo não encontrado',
+    'file_too_large' => 'Arquivo muito grande',
+    'modal_delete_heading' => 'Excluir este arquivo de log?',
+    'modal_delete_subheading' => 'Tem certeza de que deseja excluir este arquivo de log?',
+    'modal_delete_action_cancel' => 'Cancelar',
+    'modal_delete_action_confirm' => 'Excluir',
+];


### PR DESCRIPTION
This pull request adds a new set of Portuguese (Brazilian) translations for log-related functionality in the application. These translations provide localized text for navigation labels, actions, placeholders, and modal dialogs.

### Additions to Portuguese translations for log functionality:

* [`resources/lang/pt_BR/translations.php`](diffhunk://#diff-b41e0a750c15432489e265a2e1ce646c175077810dcf03fabd067d2d8374c570R1-R17): Introduced translations for log-related features, including navigation labels (`navigation_label`, `navigation_group`), actions (`delete`, `download`), and modal dialog texts (`modal_delete_heading`, `modal_delete_subheading`, `modal_delete_action_cancel`, `modal_delete_action_confirm`).